### PR TITLE
added json_safe_dict and to_json public instance methods to Review and M...

### DIFF
--- a/pitchfork/pitchfork.py
+++ b/pitchfork/pitchfork.py
@@ -100,7 +100,7 @@ class Review:
         year = self.soup.find(class_='info').h3.get_text()
         year = year[year.index(';')+1:].strip()
         return year
-    def json_safe_dict(self):
+    def _json_safe_dict(self):
         """
         Returns a dictionary representation of object where 
         the soup key's value's special characters are escaped
@@ -113,7 +113,7 @@ class Review:
         """
         Returns the attributes of the album review formatted as json.
         """
-        d = self.json_safe_dict()
+        d = self._json_safe_dict()
         return json.dumps(d)
 
     def __repr__(self):
@@ -167,7 +167,7 @@ class MultiReview(Review):
         year = year[year.index(';')+1:].strip()
         return year
 
-    def json_safe_dict(self):
+    def _json_safe_dict(self):
         """
         Returns a dictionary representation of object where 
         the soup key's value's special characters are escaped
@@ -178,7 +178,7 @@ class MultiReview(Review):
         return d
 
     def to_json(self):
-        d = self.json_safe_dict()
+        d = self._json_safe_dict()
         return json.dumps(d)
 
 def search(artist, album):

--- a/tests/test_pitchfork.py
+++ b/tests/test_pitchfork.py
@@ -28,7 +28,7 @@ class TestReview(unittest.TestCase):
         self.assertEqual(self.review.url, '/reviews/albums/19466-mogwai-come-on-die-young-deluxe-edition/')
 
     def test_review_to_json(self):
-        input_dict = self.review.json_safe_dict()
+        input_dict = self.review._json_safe_dict()
         output_dict = json.loads(self.review.to_json())
         for input_key in input_dict.keys():
             self.assertEqual(output_dict[input_key], input_dict[input_key])
@@ -58,7 +58,7 @@ class TestMultiReview(unittest.TestCase):
         self.assertEqual(self.multi_review.url, '/reviews/albums/12938-pablo-honey-collectors-edition-the-bends-collectors-edition-ok-computer-collectors-edition/')
 
     def test_multi_review_to_json(self):
-        input_dict = self.multi_review.json_safe_dict()
+        input_dict = self.multi_review._json_safe_dict()
         output_dict = json.loads(self.multi_review.to_json())
         for input_key in input_dict.keys():
             self.assertEqual(output_dict[input_key], input_dict[input_key])


### PR DESCRIPTION
I added a to_json method (and a related helper) along with unit tests to both the Review and MultiReview classes for easy-exporting of the data returned by the Pitchfork client. For example:

```
# Review
import pitchfork
p = pitchfork.search('mogwai', 'come on')
#=> {Review instance}
p.to_json()
#=> {valid json string}
```

```
# MultiReview
import pitchfork
p = pitchfork.search('radiohead, 'ok computer')
#=> {MultiReview instance}
p.to_json()
#=> {valid json string}
```
