### PR TITLE
fixed decoding bug for python2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .DS_Store
 README.rst
 pitchfork.egg-info
+.idea/**

--- a/pitchfork/pitchfork.py
+++ b/pitchfork/pitchfork.py
@@ -189,7 +189,7 @@ def search(artist, album):
                       data=None,
                       headers={'User-Agent': 'michalczaplinski/pitchfork-v0.1'})
     response = urlopen(request)
-    text = response.read().decode().split('window.App=')[1].split(';</script>')[0]
+    text = response.read().decode('UTF-8').split('window.App=')[1].split(';</script>')[0]
 
     # the server responds with json so we load it into a dictionary
     obj = json.loads(text)


### PR DESCRIPTION
Hi,

I tested the API and realized it raises the following error when running it with python 2.7:

`Traceback (most recent call last):
  File "test_pitchfork.py", line 12, in setUpClass
    cls.review = search('mogwai', 'come on')
  File "../pitchfork/pitchfork.py", line 192, in search
    text = response.read().decode().split('window.App=')[1].split(';</script>')[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 31668: ordinal not in range(128)
`

Apparently, the decode function sets the `encoding` parameter to UTF-8 by default in python3, but in python2.7 it doesn't, so I explicitly set it to UTF-8.

 